### PR TITLE
Update Readme before archiving

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 networking-ucsm-bm
 ===============================
 
+NOTE: This driver is no longer under active development.
+
 Neutron ML2 driver for Cisco UCSM managing bare metal servers
 
 This driver has been forked of SAP networking-cisco driver.


### PR DESCRIPTION
The driver is no longer in active development. We add a note about this to the readme before archiving the repo, as GitHub recommends.